### PR TITLE
Checking load before calling method against it.

### DIFF
--- a/lib/Mail/Message/Head.pm
+++ b/lib/Mail/Message/Head.pm
@@ -69,8 +69,8 @@ use overload qq("") => 'string_unless_carp'
            , bool   => 'isEmpty';
 
 # To satisfy overload in static resolving.
-sub toString() { shift->load->toString }
-sub string()   { shift->load->string }
+sub toString() { my $load = shift->load; return $load->toString if (defined $load); }
+sub string()   { my $load = shift->load; return $load->string   if (defined $load); }
 
 sub string_unless_carp()
 {   my $self = shift;


### PR DESCRIPTION
Hi @markov2 

After such a long gap, here is one PR for you to review, please.
This would hopefully resolve the fail report for your another distribution Mail::Box:

https://www.cpantesters.org/cpan/report/e839410c-2063-11e8-9917-f16481200c9d

      t/110mh-read.t ........... ok
      ERROR: Cannot create parser for t/folders/mh.src/9.
      Can't call method "toString" on an undefined value at /home/njh/.cpan/build/Mail-Message-3.006- 
      0/blib/lib/Mail/Message/Head.pm line 29.
      ERROR: Cannot create parser for t/folders/mh.src/14.
	     (in cleanup) Can't call method "toString" on an undefined value at /home/njh/.cpan/build/Mail- 
             Message-3.006-0/blib/lib/Mail/Message/Head.pm line 29.
     # Looks like your test exited with 2 just after 2.

Many Thanks.
Best Regards,
Mohammad S Anwar